### PR TITLE
feat(x402): add local demo + LinkedIn jobs x402 agents

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+# Allow git URL subdependencies (needed by react-force-graph → aframe → three-bmfont-text)
+block-exotic-subdeps=false

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,7 +34,8 @@ const nextConfig = {
                     { key: "Access-Control-Allow-Credentials", value: "true" },
                     { key: "Access-Control-Allow-Origin", value: "*" },
                     { key: "Access-Control-Allow-Methods", value: "GET,DELETE,PATCH,POST,PUT" },
-                    { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" },
+                    { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, X-PAYMENT, X-Payment, PAYMENT-SIGNATURE, Payment-Signature" },
+                    { key: "Access-Control-Expose-Headers", value: "Payment-Required, PAYMENT-REQUIRED, X-Payment-Response, X-PAYMENT-RESPONSE, PAYMENT-RESPONSE" },
                 ]
             }
         ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,6 +74,7 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "ethers": "^6.15.0",
+    "highlight.js": "^11.11.1",
     "libp2p": "^2.10.0",
     "llamaindex": "^0.9.17",
     "lucide-react": "^0.485.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS=--max-old-space-size=4096 next dev --turbopack",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -60,6 +60,9 @@
     "@tanstack/react-query": "^5.81.5",
     "@types/papaparse": "^5.3.15",
     "@wagmi/core": "^3.4.0",
+    "@x402/core": "^2.12.0",
+    "@x402/evm": "^2.12.0",
+    "@x402/fetch": "^2.12.0",
     "ai": "^5.0.26",
     "atom.io": "^0.33.8",
     "axios": "^1.8.4",
@@ -71,7 +74,7 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "ethers": "^6.15.0",
-"libp2p": "^2.10.0",
+    "libp2p": "^2.10.0",
     "llamaindex": "^0.9.17",
     "lucide-react": "^0.485.0",
     "marked": "^16.1.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -160,7 +160,16 @@ importers:
         version: 5.5.2
       '@wagmi/core':
         specifier: ^3.4.0
-        version: 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(immer@11.1.4)(ox@0.12.4(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.20(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@x402/core':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@x402/evm':
+        specifier: ^2.12.0
+        version: 2.12.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/fetch':
+        specifier: ^2.12.0
+        version: 2.12.0
       ai:
         specifier: ^5.0.26
         version: 5.0.137(zod@4.3.6)
@@ -199,7 +208,7 @@ importers:
         version: 2.10.0
       llamaindex:
         specifier: ^0.9.17
-        version: 0.9.19(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 0.9.19(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
       lucide-react:
         specifier: ^0.485.0
         version: 0.485.0(react@19.2.4)
@@ -217,7 +226,7 @@ importers:
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       openai:
         specifier: ^4.28.0
-        version: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 4.104.0(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
       papaparse:
         specifier: ^5.5.2
         version: 5.5.3
@@ -1131,9 +1140,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -1143,9 +1154,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -2576,6 +2589,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -3429,6 +3443,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vanilla-extract/css@1.17.3':
     resolution: {integrity: sha512-jHivr1UPoJTX5Uel4AZSOwrCf4mO42LcdmnhJtUxZaRWhW4FviFbIfs0moAWWld7GOT+2XnuVZjjA/K32uUnMQ==}
@@ -3580,6 +3595,15 @@ packages:
 
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
+
+  '@x402/core@2.12.0':
+    resolution: {integrity: sha512-dLae9AbZRN/W7GsKe9ngqGsflnP+esE72s0GjmqDZbPihM/tlHCA6UnDdgM0qfOiDOf9iL+mmCs1OyLWpwnGLQ==}
+
+  '@x402/evm@2.12.0':
+    resolution: {integrity: sha512-kZUoHPVdBS8wlTg5K1eoh/1V0+5n9ABGRPC5DOQwRlkAwIrAFOEi2pQE+jgvOx0iM5ib2xj9gJjpldRbasX12w==}
+
+  '@x402/fetch@2.12.0':
+    resolution: {integrity: sha512-lkN/fzkZjnbJreLwI3fessKAaTKsOrrc0mFPGHWwZy0W/s8KFusLwdHuS8ul/XdUyNcYYrwcV6z0faGGSWNUNA==}
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -6277,6 +6301,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
     peerDependencies:
@@ -7360,7 +7392,7 @@ packages:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   three-bmfont-text@https://codeload.github.com/dmarcos/three-bmfont-text/tar.gz/eed4878795be9b3e38cf6aec6b903f56acd1f695:
-    resolution: {tarball: https://codeload.github.com/dmarcos/three-bmfont-text/tar.gz/eed4878795be9b3e38cf6aec6b903f56acd1f695}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/dmarcos/three-bmfont-text/tar.gz/eed4878795be9b3e38cf6aec6b903f56acd1f695}
     version: 3.0.0
 
   three-forcegraph@1.43.1:
@@ -7693,10 +7725,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.13.2:
@@ -7740,6 +7774,14 @@ packages:
 
   viem@2.46.3:
     resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.49.3:
+    resolution: {integrity: sha512-FlIXd2kRygDxJtvjtPp74vjmyOKMjKlXXgTNdMxr8h3kcDrQ4bYb9q1MpSWyCVa3L2NJc9gSv+u8HcHYIZQUkw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9269,11 +9311,11 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.3.2(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)':
+  '@llamaindex/openai@0.3.2(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)':
     dependencies:
       '@llamaindex/core': 0.6.2
       '@llamaindex/env': 0.1.29
-      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      openai: 4.104.0(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
     transitivePeerDependencies:
       - '@huggingface/transformers'
       - encoding
@@ -9465,7 +9507,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -11854,7 +11896,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       '@noble/curves': 1.9.7
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
       agentkeepalive: 4.6.0
@@ -12343,7 +12385,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(immer@11.1.4)(ox@0.12.4(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.20(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
@@ -12351,7 +12393,7 @@ snapshots:
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.90.20
-      ox: 0.12.4(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -12901,6 +12943,24 @@ snapshots:
       '@ipld/dag-cbor': 9.2.5
       multiformats: 13.4.2
       sync-multihash-sha2: 1.0.0
+
+  '@x402/core@2.12.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.12.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.12.0
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.12.0':
+    dependencies:
+      '@x402/core': 2.12.0
 
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
@@ -15100,13 +15160,13 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llamaindex@0.9.19(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
+  llamaindex@0.9.19(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
     dependencies:
       '@llamaindex/cloud': 4.0.3(@llamaindex/core@0.6.2)(@llamaindex/env@0.1.29)
       '@llamaindex/core': 0.6.2
       '@llamaindex/env': 0.1.29
       '@llamaindex/node-parser': 2.0.2(@llamaindex/core@0.6.2)(@llamaindex/env@0.1.29)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/openai': 0.3.2(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      '@llamaindex/openai': 0.3.2(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
       '@llamaindex/workflow': 1.0.3(@llamaindex/core@0.6.2)(@llamaindex/env@0.1.29)(zod@4.3.6)
       '@types/lodash': 4.17.24
       '@types/node': 22.19.11
@@ -16008,7 +16068,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
+  openai@4.104.0(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -16018,7 +16078,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 4.3.6
     transitivePeerDependencies:
       - encoding
@@ -16101,14 +16161,45 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.20(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
   ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -17823,6 +17914,23 @@ snapshots:
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.12.4(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.49.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       ethers:
         specifier: ^6.15.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       libp2p:
         specifier: ^2.10.0
         version: 2.10.0

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@ipshipyard/node-datachannel': true
+  '@parcel/watcher': true
+  bufferutil: true
+  keccak: true
+  protobufjs: true
+  sharp: true
+  tree-sitter: true
+  utf-8-validate: true

--- a/frontend/src/app/agents.json
+++ b/frontend/src/app/agents.json
@@ -1,6 +1,28 @@
 {
   "agents": [
     {
+      "id": "demo",
+      "agentId": "demo",
+      "owner": "0x0a7c56744ed6fd786931e11e40f462cf213654b0",
+      "agentURI": "http://localhost:3000/api/demo-x402-agent/card",
+      "contractId": "local",
+      "registeredAt": "2026-05-19T00:00:00.000Z",
+      "name": "Local x402 Demo Agent",
+      "description": "Local agent that verifies x402 signed payments end-to-end (no external deps).",
+      "reputationScore": 100
+    },
+    {
+      "id": "linkedin-jobs",
+      "agentId": "linkedin-jobs",
+      "owner": "0x0a7c56744ed6fd786931e11e40f462cf213654b0",
+      "agentURI": "http://localhost:3000/api/linkedin-jobs-agent/card",
+      "contractId": "local",
+      "registeredAt": "2026-05-22T00:00:00.000Z",
+      "name": "LinkedIn Jobs Agent (24h)",
+      "description": "Pay 0.01 USDC to fetch LinkedIn job postings created in the last 24 hours for any keyword + location.",
+      "reputationScore": 90
+    },
+    {
       "id": "16",
       "agentId": "16",
       "owner": "0x0a7c56744ed6fd786931e11e40f462cf213654b0",

--- a/frontend/src/app/api/agent-service/route.ts
+++ b/frontend/src/app/api/agent-service/route.ts
@@ -1,49 +1,130 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export const maxDuration = 60; // allow up to 60s for external service calls
+export const maxDuration = 60;
 
-export async function POST(req: NextRequest) {
-  const { endpoint, inputParams, payment } = await req.json();
+function validateHttpEndpoint(endpoint: string): string | null {
+  try {
+    const parsed = new URL(endpoint);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return `Endpoint must use http or https, got: ${parsed.protocol}`;
+    }
+    return null;
+  } catch {
+    return `Invalid URL: "${endpoint}"`;
+  }
+}
+
+// GET — for polling async agent status/report endpoints
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const endpoint = url.searchParams.get("endpoint") ?? "";
 
   if (!endpoint) return NextResponse.json({ error: "Missing endpoint" }, { status: 400 });
 
-  // x402 v2: X-PAYMENT is base64url-encoded JSON of the full payment object
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
+  const validationError = validateHttpEndpoint(endpoint);
+  if (validationError) return NextResponse.json({ error: validationError }, { status: 400 });
+
+  try {
+    const res = await fetch(endpoint, { signal: AbortSignal.timeout(15000) });
+
+    if (!res.ok) {
+      let data: unknown;
+      try { data = await res.json(); } catch { data = await res.text(); }
+      return NextResponse.json({ error: `Service error ${res.status}`, details: data }, { status: res.status });
+    }
+
+    let data: unknown;
+    try { data = await res.json(); } catch { data = await res.text(); }
+    return NextResponse.json({ success: true, data });
+  } catch (err) {
+    console.error("[agent-service GET] fetch error for:", endpoint, err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error", endpoint },
+      { status: 500 }
+    );
+  }
+}
+
+// POST — transparent proxy to the agent's endpoint.
+//
+// Each agent runs its own x402 flow. ANP forwards the X-PAYMENT /
+// PAYMENT-SIGNATURE header through unchanged and returns the agent's
+// response (including 402 challenges and PAYMENT-RESPONSE receipts)
+// transparently so `wrapFetchWithPayment` on the client can complete
+// the handshake against the agent directly.
+//
+// The only ANP-hosted x402 agent today is /api/demo-x402-agent, which
+// runs its own verification. External agents either work because they
+// implement x402 correctly, or fail with their own 402 — ANP does NOT
+// act as a facilitator for them.
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({} as Record<string, unknown>));
+  const { endpoint, inputParams } = body as {
+    endpoint?: string;
+    inputParams?: Record<string, unknown>;
   };
 
-  if (payment) {
-    headers["X-PAYMENT"] = Buffer.from(JSON.stringify(payment)).toString("base64");
+  if (!endpoint) return NextResponse.json({ error: "Missing endpoint" }, { status: 400 });
+  const validationError = validateHttpEndpoint(endpoint);
+  if (validationError) return NextResponse.json({ error: validationError }, { status: 400 });
+
+  // Forward the payment header(s) if present.
+  const paymentHeader =
+    req.headers.get("payment-signature") ?? req.headers.get("x-payment");
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (paymentHeader) {
+    headers["PAYMENT-SIGNATURE"] = paymentHeader;
+    headers["X-PAYMENT"] = paymentHeader;
   }
 
   try {
     const res = await fetch(endpoint, {
       method: "POST",
       headers,
-      body: JSON.stringify(inputParams),
+      body: JSON.stringify(inputParams ?? {}),
       signal: AbortSignal.timeout(30000),
     });
 
-    const body = await res.text();
+    // Read body once
     let data: unknown;
-    try { data = JSON.parse(body); } catch { data = body; }
+    let raw = "";
+    try {
+      raw = await res.text();
+      data = raw ? JSON.parse(raw) : raw;
+    } catch {
+      data = raw;
+    }
 
+    // 402 → pass through unchanged so wrapFetchWithPayment can sign + retry.
     if (res.status === 402) {
-      // Return the 402 details so the client can debug
-      return NextResponse.json(
-        { error: "Payment rejected by service", details: data },
-        { status: 402 }
-      );
+      const passthrough = NextResponse.json(data ?? {}, { status: 402 });
+      const challenge = res.headers.get("payment-required") ?? res.headers.get("PAYMENT-REQUIRED");
+      if (challenge) passthrough.headers.set("PAYMENT-REQUIRED", challenge);
+      return passthrough;
     }
 
     if (!res.ok) {
-      return NextResponse.json({ error: `Service error ${res.status}`, details: data }, { status: res.status });
+      return NextResponse.json(
+        { error: `Agent error ${res.status}`, details: data },
+        { status: res.status },
+      );
     }
 
-    return NextResponse.json({ success: true, data });
+    // Pass through PAYMENT-RESPONSE receipt headers so the client x402
+    // library can parse the settlement result.
+    const response = NextResponse.json({ success: true, data });
+    const receipt =
+      res.headers.get("payment-response") ??
+      res.headers.get("x-payment-response");
+    if (receipt) {
+      response.headers.set("PAYMENT-RESPONSE", receipt);
+      response.headers.set("X-Payment-Response", receipt);
+    }
+    return response;
   } catch (err) {
+    console.error("[agent-service POST] fetch error for:", endpoint, err);
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unknown error" },
+      { error: err instanceof Error ? err.message : "Unknown error", endpoint },
       { status: 500 }
     );
   }

--- a/frontend/src/app/api/agents/[id]/route.ts
+++ b/frontend/src/app/api/agents/[id]/route.ts
@@ -34,8 +34,12 @@ export async function GET(
       payTo: s.payTo ?? s.payment?.payTo ?? agentWalletAddress,
       asset: s.asset ?? s.payment?.asset ?? "",
       network: s.network ?? s.payment?.network ?? "",
-      cost: s.cost ?? s.payment?.amount ?? "",
+      // Prefer the human-readable cost ("0.001") over the raw on-chain amount ("1000")
+      // so display + balance-check + LLM tool params all use the same units.
+      cost: s.cost ?? s.payment?.cost ?? s.payment?.amount ?? "",
       currency: s.currency ?? s.payment?.currency ?? "",
+      // Raw on-chain amount in minor units (e.g. "1000" = 0.001 USDC) — kept for diagnostics.
+      amount: s.payment?.amount ?? "",
     }));
 
   return NextResponse.json({

--- a/frontend/src/app/api/agents/route.ts
+++ b/frontend/src/app/api/agents/route.ts
@@ -25,10 +25,27 @@ function staticAgents() {
   }));
 }
 
+// Agents that aren't registered on-chain (e.g., local demo agents) — always prepended.
+function localAgents() {
+  return (agentsData.agents as any[])
+    .filter((a) => a.contractId === "local")
+    .map((a) => ({
+      id: a.id,
+      agentId: a.agentId,
+      owner: a.owner,
+      agentURI: a.agentURI,
+      contractId: a.contractId,
+      registeredAt: a.registeredAt,
+      name: a.name,
+      description: a.description,
+      reputationScore: a.reputationScore ?? 50,
+    }));
+}
+
 async function refreshCache(cacheKey: string, pageSize: number, skip: number) {
   try {
     const registered = await getRegisteredAgents(pageSize, skip);
-    const agents = registered.map((entry) => {
+    const onChain = registered.map((entry) => {
       const stored = storedAgents.get(String(entry.agentId));
       return {
         id: entry.agentId,
@@ -42,6 +59,7 @@ async function refreshCache(cacheKey: string, pageSize: number, skip: number) {
         reputationScore: 50,
       };
     });
+    const agents = [...localAgents(), ...onChain];
     pageCache.set(cacheKey, { agents, expiresAt: Date.now() + CACHE_TTL });
   } catch {
     // subgraph unavailable — cached static fallback stays in place
@@ -66,7 +84,12 @@ export async function GET(request: NextRequest) {
   }
 
   // Cold start: seed cache with static data immediately, kick off background refresh
-  const fallback = staticAgents();
+  const localFirst = localAgents();
+  const staticIds = new Set(localFirst.map(a => String(a.agentId)));
+  const fallback = [
+    ...localFirst,
+    ...staticAgents().filter(a => !staticIds.has(String(a.agentId))),
+  ];
   pageCache.set(cacheKey, { agents: fallback, expiresAt: Date.now() + CACHE_TTL });
   refreshCache(cacheKey, pageSize, skip);
   return NextResponse.json({ agents: fallback, page, pageSize, total: fallback.length });

--- a/frontend/src/app/api/demo-x402-agent/card/route.ts
+++ b/frontend/src/app/api/demo-x402-agent/card/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Agent card for the local x402 demo agent.
+ *
+ * Served from this Next.js route so the agent can be referenced by URL like a
+ * normal remote agent, but everything runs locally for end-to-end demo.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const endpoint = `${url.origin}/api/demo-x402-agent`;
+  const wallet = "0x0A7c56744ed6fd786931E11E40F462CF213654b0";
+
+  return NextResponse.json({
+    name: "Local x402 Demo Agent",
+    description:
+      "Verifies your EIP-712 signed payment authorization against the USDC contract on Base Sepolia and returns a success receipt. Demonstrates the x402 signature flow end-to-end without relying on external services.",
+    active: true,
+    x402Support: true,
+    services: [
+      {
+        name: "agentWallet",
+        endpoint: `eip155:84532:${wallet}`,
+      },
+      {
+        id: "verify-payment",
+        name: "Verify Signed Payment",
+        description:
+          "Submit a signed x402 payment and receive a verification receipt. Costs 0.001 USDC on Base Sepolia (signature only; no on-chain settlement in demo mode).",
+        endpoint,
+        inputSchema: {
+          type: "object",
+          properties: {
+            task: {
+              type: "string",
+              description: "Optional task description to echo back in the receipt",
+            },
+          },
+        },
+        payment: {
+          scheme: "exact",
+          network: "eip155:84532",
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          amount: "1000",
+          payTo: wallet,
+          currency: "USDC",
+          cost: "0.001",
+          maxTimeoutSeconds: 300,
+        },
+      },
+    ],
+    anp: {
+      systemPrompt: [
+        "You are the Local x402 Demo Agent. You expose exactly one paid service: `verify-payment`.",
+        "",
+        "When the user asks to use, call, run, or trigger the service, IMMEDIATELY call the requestAgentService tool with EXACTLY these values (do NOT invent or change them):",
+        `- serviceName: "Verify Signed Payment"`,
+        `- endpoint: "${endpoint}"`,
+        `- description: "Submit a signed x402 payment and receive a verification receipt."`,
+        `- cost: "0.001"`,
+        `- currency: "USDC"`,
+        `- network: "eip155:84532"`,
+        `- payTo: "${wallet}"`,
+        `- asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"`,
+        `- inputParams: { task: <the task string the user provided, or "hello" if none> }`,
+        "",
+        "Never claim the cost is ETH. Never use a different endpoint. Never ask for confirmation — call the tool immediately.",
+      ].join("\n"),
+      tools: [],
+      knowledge_sources: [],
+      privacy_level: "low",
+      stake: 0,
+    },
+  });
+}

--- a/frontend/src/app/api/demo-x402-agent/route.ts
+++ b/frontend/src/app/api/demo-x402-agent/route.ts
@@ -1,0 +1,202 @@
+/**
+ * Local x402 demo agent.
+ *
+ * Purpose: verify the *signature flow* end-to-end without depending on any
+ * external agent / facilitator. This route:
+ *   1. Returns 402 + a valid Payment-Required challenge when called without payment.
+ *   2. When called with `PAYMENT-SIGNATURE` (v2) or `X-PAYMENT` (v1), decodes,
+ *      validates the EIP-712 TransferWithAuthorization signature against the
+ *      expected USDC domain on Base Sepolia, and returns 200 with a payload.
+ *
+ * It does NOT submit the transferWithAuthorization on-chain (no facilitator,
+ * no broadcaster). This is solely to prove the signing/verification half of
+ * the x402 protocol works in this repo. For real settlement you need a
+ * facilitator with a funded relayer + (optionally) CDP API keys.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyTypedData, getAddress, type Hex } from "viem";
+
+const BASE_SEPOLIA_USDC = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+const DEMO_PAY_TO = "0x0A7c56744ed6fd786931E11E40F462CF213654b0";
+const DEMO_AMOUNT = "1000"; // 0.001 USDC (6 decimals)
+const NETWORK = "eip155:84532";
+
+const authorizationTypes = {
+  TransferWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+function buildChallenge(req: NextRequest) {
+  const url = new URL(req.url);
+  return {
+    x402Version: 2 as const,
+    error: "Payment required",
+    resource: {
+      url: `${url.origin}${url.pathname}`,
+      description: "Local x402 demo agent — verifies signed payment payload",
+      mimeType: "application/json",
+    },
+    accepts: [
+      {
+        scheme: "exact",
+        network: NETWORK,
+        asset: BASE_SEPOLIA_USDC,
+        amount: DEMO_AMOUNT,
+        payTo: DEMO_PAY_TO,
+        maxTimeoutSeconds: 300,
+        extra: { name: "USD Coin", version: "2" },
+      },
+    ],
+  };
+}
+
+function paymentRequired(req: NextRequest, error?: string) {
+  const challenge = buildChallenge(req);
+  if (error) challenge.error = error;
+  const encoded = Buffer.from(JSON.stringify(challenge)).toString("base64");
+  return NextResponse.json(challenge, {
+    status: 402,
+    headers: { "Payment-Required": encoded },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  // GET surfaces the challenge so the demo flow can be inspected from a browser
+  return paymentRequired(req);
+}
+
+export async function POST(req: NextRequest) {
+  const paymentHeader =
+    req.headers.get("payment-signature") ?? req.headers.get("x-payment");
+
+  if (!paymentHeader) return paymentRequired(req);
+
+  // Decode the base64 payment payload
+  let payload: {
+    x402Version?: number;
+    payload?: {
+      authorization?: {
+        from: string;
+        to: string;
+        value: string;
+        validAfter: string;
+        validBefore: string;
+        nonce: string;
+      };
+      signature?: string;
+    };
+    accepted?: { asset?: string; payTo?: string; amount?: string; network?: string };
+  };
+  try {
+    const json = Buffer.from(paymentHeader, "base64").toString("utf8");
+    payload = JSON.parse(json);
+  } catch {
+    return paymentRequired(req, "Malformed payment header (invalid base64/JSON)");
+  }
+
+  const auth = payload?.payload?.authorization;
+  const signature = payload?.payload?.signature as Hex | undefined;
+  if (!auth || !signature) {
+    return paymentRequired(req, "Missing authorization or signature in payload");
+  }
+
+  // Cross-check declared accepted matches what we asked for
+  const accepted = payload.accepted;
+  if (accepted) {
+    if (accepted.asset && getAddress(accepted.asset) !== getAddress(BASE_SEPOLIA_USDC)) {
+      return paymentRequired(req, `Wrong asset: expected ${BASE_SEPOLIA_USDC}`);
+    }
+    if (accepted.payTo && getAddress(accepted.payTo) !== getAddress(DEMO_PAY_TO)) {
+      return paymentRequired(req, `Wrong payTo: expected ${DEMO_PAY_TO}`);
+    }
+    if (accepted.amount && accepted.amount !== DEMO_AMOUNT) {
+      return paymentRequired(req, `Wrong amount: expected ${DEMO_AMOUNT}`);
+    }
+  }
+
+  // Validate window
+  const now = Math.floor(Date.now() / 1000);
+  const validAfter = Number(auth.validAfter);
+  const validBefore = Number(auth.validBefore);
+  if (now < validAfter) return paymentRequired(req, "Authorization not yet valid");
+  if (now > validBefore) return paymentRequired(req, "Authorization expired");
+
+  // Verify EIP-712 signature against USDC domain on Base Sepolia
+  const domain = {
+    name: "USD Coin",
+    version: "2",
+    chainId: 84532,
+    verifyingContract: getAddress(BASE_SEPOLIA_USDC),
+  } as const;
+  const message = {
+    from: getAddress(auth.from),
+    to: getAddress(auth.to),
+    value: BigInt(auth.value),
+    validAfter: BigInt(auth.validAfter),
+    validBefore: BigInt(auth.validBefore),
+    nonce: auth.nonce as Hex,
+  };
+
+  let valid = false;
+  try {
+    valid = await verifyTypedData({
+      address: getAddress(auth.from) as `0x${string}`,
+      domain,
+      types: authorizationTypes,
+      primaryType: "TransferWithAuthorization",
+      message,
+      signature,
+    });
+  } catch (err) {
+    return paymentRequired(
+      req,
+      `Signature verification threw: ${err instanceof Error ? err.message : "unknown"}`,
+    );
+  }
+
+  if (!valid) return paymentRequired(req, "EIP-712 signature did not recover to `from`");
+
+  // Success! In a real flow the facilitator would broadcast transferWithAuthorization
+  // here. We just acknowledge.
+  let body: Record<string, unknown> = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* body optional */
+  }
+
+  const receipt = {
+    success: true,
+    verified: {
+      from: auth.from,
+      to: auth.to,
+      value: auth.value,
+      nonce: auth.nonce,
+    },
+    settlement: "NOT_BROADCAST_DEMO_MODE",
+    note:
+      "Signature is valid. In production, a facilitator would submit transferWithAuthorization(...) on-chain.",
+    input: body,
+  };
+
+  // Echo a base64 receipt header so wrapFetchWithPayment can parse it
+  const receiptHeader = Buffer.from(
+    JSON.stringify({ x402Version: 2, success: true, settlement: "demo" }),
+  ).toString("base64");
+
+  return NextResponse.json(receipt, {
+    status: 200,
+    headers: {
+      "PAYMENT-RESPONSE": receiptHeader,
+      "X-Payment-Response": receiptHeader,
+      "Access-Control-Expose-Headers": "PAYMENT-RESPONSE,X-Payment-Response",
+    },
+  });
+}

--- a/frontend/src/app/api/linkedin-jobs-agent/card/route.ts
+++ b/frontend/src/app/api/linkedin-jobs-agent/card/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Agent card for the LinkedIn Jobs x402 agent.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const endpoint = `${url.origin}/api/linkedin-jobs-agent`;
+  const wallet = "0x0A7c56744ed6fd786931E11E40F462CF213654b0";
+
+  return NextResponse.json({
+    name: "LinkedIn Jobs Agent (24h)",
+    description:
+      "Paid agent that scrapes LinkedIn job postings created in the last 24 hours for a given keyword + location. Pay 0.01 USDC on Base Sepolia per query.",
+    active: true,
+    x402Support: true,
+    services: [
+      {
+        name: "agentWallet",
+        endpoint: `eip155:84532:${wallet}`,
+      },
+      {
+        id: "fetch-recent-jobs",
+        name: "Fetch Recent LinkedIn Jobs",
+        description:
+          "Returns LinkedIn job postings created in the last 24 hours matching `keywords` (e.g. 'software engineer') and optional `location` (e.g. 'San Francisco'). Costs 0.01 USDC on Base Sepolia.",
+        endpoint,
+        inputSchema: {
+          type: "object",
+          required: ["keywords"],
+          properties: {
+            keywords: {
+              type: "string",
+              description: "Job title or skill, e.g. 'rust backend engineer'",
+            },
+            location: {
+              type: "string",
+              description: "Location filter, e.g. 'Remote', 'New York', 'Germany'",
+            },
+            limit: {
+              type: "number",
+              description: "Max jobs to return (1–25, default 10)",
+            },
+          },
+        },
+        payment: {
+          scheme: "exact",
+          network: "eip155:84532",
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          amount: "10000",
+          payTo: wallet,
+          currency: "USDC",
+          cost: "0.01",
+          maxTimeoutSeconds: 300,
+        },
+      },
+    ],
+    anp: {
+      systemPrompt: [
+        "You are the LinkedIn Jobs Agent. You expose exactly one paid service: `fetch-recent-jobs`.",
+        "It returns LinkedIn job postings created in the LAST 24 HOURS.",
+        "",
+        "When the user asks for recent jobs / job openings / new postings, IMMEDIATELY call the requestAgentService tool with EXACTLY these values:",
+        `- serviceName: "Fetch Recent LinkedIn Jobs"`,
+        `- endpoint: "${endpoint}"`,
+        `- description: "Scrape LinkedIn jobs posted in the last 24 hours."`,
+        `- cost: "0.01"`,
+        `- currency: "USDC"`,
+        `- network: "eip155:84532"`,
+        `- payTo: "${wallet}"`,
+        `- asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"`,
+        "- inputParams: { keywords: <extracted from the user message, e.g. 'software engineer'>, location: <extracted, default 'United States'>, limit: <1-25, default 10> }",
+        "",
+        "Always extract `keywords` from the user's message. If they don't say a location, default to 'United States'. Never ask for confirmation — call the tool immediately. Never claim the cost is ETH.",
+      ].join("\n"),
+      tools: [],
+      knowledge_sources: [],
+      privacy_level: "low",
+      stake: 0,
+    },
+  });
+}

--- a/frontend/src/app/api/linkedin-jobs-agent/route.ts
+++ b/frontend/src/app/api/linkedin-jobs-agent/route.ts
@@ -1,0 +1,304 @@
+/**
+ * LinkedIn Jobs x402 Agent.
+ *
+ * Paid agent that scrapes LinkedIn's public guest job-search endpoint for
+ * postings created in the last 24 hours, given a `keywords` and (optional)
+ * `location` query.
+ *
+ * Flow mirrors /api/demo-x402-agent:
+ *   1. POST without payment → 402 + Payment-Required challenge.
+ *   2. POST with valid x402 EIP-712 signature → 200 with parsed job list.
+ *
+ * Cost: 0.01 USDC on Base Sepolia.
+ *
+ * NOTE: Uses LinkedIn's public guest endpoint (no auth required). LinkedIn may
+ * rate-limit or block requests; in those cases the agent returns the upstream
+ * status code with a `note` so the caller can see what happened.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyTypedData, getAddress, type Hex } from "viem";
+
+const BASE_SEPOLIA_USDC = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+const PAY_TO = "0x0A7c56744ed6fd786931E11E40F462CF213654b0";
+const AMOUNT = "10000"; // 0.01 USDC (6 decimals)
+const NETWORK = "eip155:84532";
+
+const authorizationTypes = {
+  TransferWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+function buildChallenge(req: NextRequest) {
+  const url = new URL(req.url);
+  return {
+    x402Version: 2 as const,
+    error: "Payment required",
+    resource: {
+      url: `${url.origin}${url.pathname}`,
+      description: "LinkedIn jobs agent — scrapes postings from the last 24h",
+      mimeType: "application/json",
+    },
+    accepts: [
+      {
+        scheme: "exact",
+        network: NETWORK,
+        asset: BASE_SEPOLIA_USDC,
+        amount: AMOUNT,
+        payTo: PAY_TO,
+        maxTimeoutSeconds: 300,
+        extra: { name: "USD Coin", version: "2" },
+      },
+    ],
+  };
+}
+
+function paymentRequired(req: NextRequest, error?: string) {
+  const challenge = buildChallenge(req);
+  if (error) challenge.error = error;
+  const encoded = Buffer.from(JSON.stringify(challenge)).toString("base64");
+  return NextResponse.json(challenge, {
+    status: 402,
+    headers: { "Payment-Required": encoded },
+  });
+}
+
+interface Job {
+  title: string;
+  company: string;
+  location: string;
+  url: string;
+  postedAgo: string;
+}
+
+/**
+ * Hits LinkedIn's public guest search endpoint and parses the returned HTML
+ * cards. `f_TPR=r86400` = past 24 hours.
+ */
+async function scrapeLinkedInJobs(
+  keywords: string,
+  location: string,
+  limit: number,
+): Promise<{ jobs: Job[]; status: number; note?: string }> {
+  const params = new URLSearchParams({
+    keywords,
+    location,
+    f_TPR: "r86400",
+    start: "0",
+  });
+  const url = `https://www.linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search?${params}`;
+
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+      Accept: "text/html,application/xhtml+xml",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+    signal: AbortSignal.timeout(20000),
+  });
+
+  if (!res.ok) {
+    return {
+      jobs: [],
+      status: res.status,
+      note: `LinkedIn responded ${res.status}. They may be rate-limiting; try again in a minute or change keywords/location.`,
+    };
+  }
+
+  const html = await res.text();
+
+  // Each job is wrapped in <li>…<div class="base-card">…</div></li>
+  const cardBlocks = html.split(/<li[^>]*>/i).slice(1);
+  const jobs: Job[] = [];
+
+  for (const block of cardBlocks) {
+    if (jobs.length >= limit) break;
+
+    const titleMatch = block.match(
+      /class="base-search-card__title[^"]*"[^>]*>\s*([\s\S]*?)\s*<\/h3>/i,
+    );
+    const companyMatch = block.match(
+      /class="base-search-card__subtitle[^"]*"[^>]*>[\s\S]*?<a[^>]*>\s*([\s\S]*?)\s*<\/a>/i,
+    );
+    const locationMatch = block.match(
+      /class="job-search-card__location[^"]*"[^>]*>\s*([\s\S]*?)\s*<\/span>/i,
+    );
+    const urlMatch = block.match(
+      /href="(https:\/\/www\.linkedin\.com\/jobs\/view\/[^"?#]+)/i,
+    );
+    const timeMatch = block.match(
+      /<time[^>]*>\s*([\s\S]*?)\s*<\/time>/i,
+    );
+
+    if (!titleMatch || !urlMatch) continue;
+
+    const clean = (s: string) =>
+      s
+        .replace(/<[^>]+>/g, "")
+        .replace(/&amp;/g, "&")
+        .replace(/&#x27;/g, "'")
+        .replace(/&quot;/g, '"')
+        .replace(/\s+/g, " ")
+        .trim();
+
+    jobs.push({
+      title: clean(titleMatch[1]),
+      company: companyMatch ? clean(companyMatch[1]) : "Unknown",
+      location: locationMatch ? clean(locationMatch[1]) : "Unknown",
+      url: urlMatch[1],
+      postedAgo: timeMatch ? clean(timeMatch[1]) : "recent",
+    });
+  }
+
+  return { jobs, status: 200 };
+}
+
+export async function GET(req: NextRequest) {
+  return paymentRequired(req);
+}
+
+export async function POST(req: NextRequest) {
+  const paymentHeader =
+    req.headers.get("payment-signature") ?? req.headers.get("x-payment");
+
+  if (!paymentHeader) return paymentRequired(req);
+
+  // Decode x402 payment payload
+  let payload: {
+    x402Version?: number;
+    payload?: {
+      authorization?: {
+        from: string;
+        to: string;
+        value: string;
+        validAfter: string;
+        validBefore: string;
+        nonce: string;
+      };
+      signature?: string;
+    };
+    accepted?: { asset?: string; payTo?: string; amount?: string; network?: string };
+  };
+  try {
+    const json = Buffer.from(paymentHeader, "base64").toString("utf8");
+    payload = JSON.parse(json);
+  } catch {
+    return paymentRequired(req, "Malformed payment header (invalid base64/JSON)");
+  }
+
+  const auth = payload?.payload?.authorization;
+  const signature = payload?.payload?.signature as Hex | undefined;
+  if (!auth || !signature) {
+    return paymentRequired(req, "Missing authorization or signature in payload");
+  }
+
+  const accepted = payload.accepted;
+  if (accepted) {
+    if (accepted.asset && getAddress(accepted.asset) !== getAddress(BASE_SEPOLIA_USDC)) {
+      return paymentRequired(req, `Wrong asset: expected ${BASE_SEPOLIA_USDC}`);
+    }
+    if (accepted.payTo && getAddress(accepted.payTo) !== getAddress(PAY_TO)) {
+      return paymentRequired(req, `Wrong payTo: expected ${PAY_TO}`);
+    }
+    if (accepted.amount && accepted.amount !== AMOUNT) {
+      return paymentRequired(req, `Wrong amount: expected ${AMOUNT}`);
+    }
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (now < Number(auth.validAfter)) return paymentRequired(req, "Authorization not yet valid");
+  if (now > Number(auth.validBefore)) return paymentRequired(req, "Authorization expired");
+
+  const domain = {
+    name: "USD Coin",
+    version: "2",
+    chainId: 84532,
+    verifyingContract: getAddress(BASE_SEPOLIA_USDC),
+  } as const;
+  const message = {
+    from: getAddress(auth.from),
+    to: getAddress(auth.to),
+    value: BigInt(auth.value),
+    validAfter: BigInt(auth.validAfter),
+    validBefore: BigInt(auth.validBefore),
+    nonce: auth.nonce as Hex,
+  };
+
+  let valid = false;
+  try {
+    valid = await verifyTypedData({
+      address: getAddress(auth.from) as `0x${string}`,
+      domain,
+      types: authorizationTypes,
+      primaryType: "TransferWithAuthorization",
+      message,
+      signature,
+    });
+  } catch (err) {
+    return paymentRequired(
+      req,
+      `Signature verification threw: ${err instanceof Error ? err.message : "unknown"}`,
+    );
+  }
+
+  if (!valid) return paymentRequired(req, "EIP-712 signature did not recover to `from`");
+
+  // Payment verified — now do the actual work
+  let body: { keywords?: string; location?: string; limit?: number } = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* body optional */
+  }
+
+  const keywords = (body.keywords ?? "software engineer").toString().slice(0, 200);
+  const location = (body.location ?? "United States").toString().slice(0, 200);
+  const limit = Math.min(Math.max(Number(body.limit) || 10, 1), 25);
+
+  let result: { jobs: Job[]; status: number; note?: string };
+  try {
+    result = await scrapeLinkedInJobs(keywords, location, limit);
+  } catch (err) {
+    result = {
+      jobs: [],
+      status: 500,
+      note: `Scrape failed: ${err instanceof Error ? err.message : "unknown"}`,
+    };
+  }
+
+  const receipt = {
+    success: true,
+    query: { keywords, location, limit, postedWithin: "24h" },
+    upstreamStatus: result.status,
+    count: result.jobs.length,
+    jobs: result.jobs,
+    note: result.note,
+    verified: {
+      from: auth.from,
+      to: auth.to,
+      value: auth.value,
+      nonce: auth.nonce,
+    },
+    settlement: "NOT_BROADCAST_DEMO_MODE",
+  };
+
+  const receiptHeader = Buffer.from(
+    JSON.stringify({ x402Version: 2, success: true, settlement: "demo" }),
+  ).toString("base64");
+
+  return NextResponse.json(receipt, {
+    status: 200,
+    headers: {
+      "PAYMENT-RESPONSE": receiptHeader,
+      "X-Payment-Response": receiptHeader,
+      "Access-Control-Expose-Headers": "PAYMENT-RESPONSE,X-Payment-Response",
+    },
+  });
+}

--- a/frontend/src/app/api/primitives/chatbot/route.ts
+++ b/frontend/src/app/api/primitives/chatbot/route.ts
@@ -1,4 +1,4 @@
-import { openai } from "@ai-sdk/openai"
+import { google } from "@ai-sdk/google"
 import { convertToModelMessages, stepCountIs, streamText, tool, UIMessage } from "ai"
 import { z } from "zod"
 
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: google("gemini-2.0-flash"),
     system: `You are a helpful assistant with access to tools. When a message starts with [Agent Context], you are acting AS that agent — adopt its persona completely.
 
 RULE 1 — Answering "what can you do":

--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { use } from "react";
-import AgentAwareChatbot from "@/components/primitives/AgentAwareChatbot";
+import dynamic from "next/dynamic";
+
+// Disable SSR — AgentAwareChatbot reads localStorage on initial render,
+// which causes a hydration mismatch with the server-rendered empty state.
+const AgentAwareChatbot = dynamic(
+  () => import("@/components/primitives/AgentAwareChatbot"),
+  { ssr: false }
+);
 
 export default function ChatConversationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,28 +2,30 @@
 
 import { WagmiProvider } from "wagmi";
 import { filecoin, filecoinCalibration, baseSepolia } from "wagmi/chains";
-import { http, createConfig } from "@wagmi/core";
+import { http } from "@wagmi/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import { getDefaultConfig, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 
 const queryClient = new QueryClient();
 
-const config = createConfig({
-  chains: [filecoinCalibration, filecoin, baseSepolia],
-  connectors: [],
+const config = getDefaultConfig({
+  appName: "Agent Nexus Protocol",
+  projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? "00000000000000000000000000000000",
+  chains: [baseSepolia, filecoinCalibration, filecoin],
   transports: {
+    [baseSepolia.id]: http(),
     [filecoin.id]: http(),
     [filecoinCalibration.id]: http(),
-    [baseSepolia.id]: http(),
   },
+  ssr: false,
 });
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <WagmiProvider config={config}>
-        <RainbowKitProvider modalSize="compact" initialChain={filecoinCalibration.id}>
+        <RainbowKitProvider modalSize="compact" initialChain={baseSepolia.id}>
           {children}
         </RainbowKitProvider>
       </WagmiProvider>

--- a/frontend/src/components/ContentRenderer.tsx
+++ b/frontend/src/components/ContentRenderer.tsx
@@ -20,7 +20,7 @@ import { toast } from "sonner"
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
-import 'highlight.js/styles/github.css'
+import '@/styles/highlight-github.css'
 
 interface ContentRendererProps {
   contentType: ContentType

--- a/frontend/src/components/primitives/PaymentApprovalCard.tsx
+++ b/frontend/src/components/primitives/PaymentApprovalCard.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { useAccount, useSignTypedData, useSwitchChain } from "wagmi";
+import { useAccount, useSwitchChain, useWalletClient, usePublicClient } from "wagmi";
+import type { PublicClient } from "viem";
 import { baseSepolia } from "wagmi/chains";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, XCircle, Loader2, Wallet, ExternalLink } from "lucide-react";
-import { toHex, pad, parseUnits } from "viem";
+import { x402Client } from "@x402/core/client";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { toClientEvmSigner } from "@x402/evm";
+import { wrapFetchWithPayment } from "@x402/fetch";
 
 interface PaymentRequest {
   serviceName: string;
@@ -19,24 +23,14 @@ interface PaymentRequest {
   inputParams: Record<string, unknown>;
 }
 
-type State = "idle" | "switching" | "signing" | "calling" | "done" | "denied" | "error";
-
-// EIP-712 domain + types for EIP-3009 transferWithAuthorization (USDC v2)
-const EIP3009_TYPES = {
-  TransferWithAuthorization: [
-    { name: "from", type: "address" },
-    { name: "to", type: "address" },
-    { name: "value", type: "uint256" },
-    { name: "validAfter", type: "uint256" },
-    { name: "validBefore", type: "uint256" },
-    { name: "nonce", type: "bytes32" },
-  ],
-} as const;
+type State = "idle" | "switching" | "calling" | "signing" | "done" | "denied" | "error";
 
 export function PaymentApprovalCard({ request }: { request: PaymentRequest }) {
   const { address, chain } = useAccount();
   const { switchChainAsync } = useSwitchChain();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { data: walletClient } = useWalletClient();
+  // Pin to Base Sepolia so the client is correct even when connected chain differs
+  const publicClient = usePublicClient({ chainId: baseSepolia.id }) as PublicClient;
 
   const [state, setState] = useState<State>("idle");
   const [result, setResult] = useState<Record<string, unknown> | null>(null);
@@ -48,97 +42,137 @@ export function PaymentApprovalCard({ request }: { request: PaymentRequest }) {
       setState("error");
       return;
     }
+    if (!walletClient || !publicClient) {
+      setErrorMsg("Wallet not ready � please reconnect.");
+      setState("error");
+      return;
+    }
+
+    setErrorMsg("");
 
     try {
       // 1. Switch to Base Sepolia if needed
       if (chain?.id !== baseSepolia.id) {
         setState("switching");
-        await switchChainAsync({ chainId: baseSepolia.id });
+        try {
+          await switchChainAsync({ chainId: baseSepolia.id });
+        } catch {
+          setErrorMsg("Please click \u2018Approve\u2019 in the MetaMask \u2018Switch to Base Sepolia\u2019 popup, then try again.");
+          setState("error");
+          return;
+        }
       }
 
-      setState("signing");
-
-      // 2. Build EIP-3009 authorization params
-      const amount = parseUnits(request.cost, 6); // USDC = 6 decimals
-      const validAfter = BigInt(0);
-      const validBefore = BigInt(Math.floor(Date.now() / 1000) + 300); // 5 min window
-      // Random 32-byte nonce
-      const nonceBytes = new Uint8Array(32);
-      crypto.getRandomValues(nonceBytes);
-      const nonce = toHex(nonceBytes) as `0x${string}`;
-
-      const domain = {
-        name: "USD Coin",
-        version: "2",
-        chainId: baseSepolia.id,
-        verifyingContract: request.asset as `0x${string}`,
-      };
-
-      const message = {
-        from: address,
-        to: request.payTo as `0x${string}`,
-        value: amount,
-        validAfter,
-        validBefore,
-        nonce,
-      };
-
-      // 3. Sign — opens wallet popup (signature only, no gas)
-      const signature = await signTypedDataAsync({
-        domain,
-        types: EIP3009_TYPES,
-        primaryType: "TransferWithAuthorization",
-        message,
-      });
-
-      // 4. Build x402 v2 payment payload and call service
       setState("calling");
 
-      const paymentPayload = {
-        x402Version: 2,
-        scheme: "exact",
-        network: request.network || "eip155:84532",
-        payload: {
-          signature,
-          authorization: {
-            from: address,
-            to: request.payTo,
-            value: amount.toString(),
-            validAfter: validAfter.toString(),
-            validBefore: validBefore.toString(),
-            nonce,
+      // Safety net: replace common placeholder strings with the real wallet address
+      const PLACEHOLDERS = ["USER_WALLET_ADDRESS", "YOUR_WALLET_ADDRESS", "WALLET_ADDRESS", "user_wallet_address"];
+      const resolvedInputParams = Object.fromEntries(
+        Object.entries(request.inputParams).map(([k, v]) => [
+          k,
+          PLACEHOLDERS.includes(String(v)) ? (address ?? "unknown") : v,
+        ])
+      );
+
+      // Pre-flight USDC balance check
+      if (request.asset && request.asset.startsWith("0x")) {
+        try {
+          const balance = await publicClient.readContract({
+            address: request.asset as `0x${string}`,
+            abi: [{ name: "balanceOf", type: "function", inputs: [{ name: "account", type: "address" }], outputs: [{ name: "", type: "uint256" }], stateMutability: "view" }] as const,
+            functionName: "balanceOf",
+            args: [address!],
+          }) as bigint;
+          const costNum = parseFloat(request.cost ?? "0");
+          const requiredRaw = BigInt(Math.ceil(costNum * 1_000_000));
+          if (balance < requiredRaw) {
+            const balanceFormatted = (Number(balance) / 1_000_000).toFixed(4);
+            setErrorMsg(
+              `Insufficient USDC � you have $${balanceFormatted} but need $${costNum} on Base Sepolia. Get test USDC at faucet.circle.com`
+            );
+            setState("error");
+            return;
+          }
+        } catch {
+          // Balance check failed � proceed anyway
+        }
+      }
+
+      // 2. Build x402 signer
+      const signer = toClientEvmSigner(
+        {
+          address,
+          signTypedData: async (msg) => {
+            setState("signing");
+            try {
+              const sig = await walletClient.signTypedData({
+                ...msg,
+                account: address,
+              } as Parameters<typeof walletClient.signTypedData>[0]);
+              setState("calling");
+              return sig;
+            } catch (sigErr) {
+              // Tag user-rejection so outer catch can give a clear message
+              throw new Error("__SIGN_REJECTED__: " + (sigErr instanceof Error ? sigErr.message : ""));
+            }
           },
         },
-      };
+        publicClient as Parameters<typeof toClientEvmSigner>[1],
+      );
 
-      const res = await fetch("/api/agent-service", {
+      const client = new x402Client();
+      client.register("eip155:*", new ExactEvmScheme(signer));
+      const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+      const res = await fetchWithPayment("/api/agent-service", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           endpoint: request.endpoint,
-          inputParams: request.inputParams,
-          payment: paymentPayload,
+          inputParams: resolvedInputParams,
         }),
       });
 
       const json = await res.json();
-      if (!res.ok) throw new Error(json.error ?? `Service error ${res.status}`);
+      if (!res.ok) {
+        if (res.status === 402) {
+          let balance = "unknown";
+          try {
+            const bal = await publicClient.readContract({
+              address: request.asset as `0x${string}`,
+              abi: [{ name: "balanceOf", type: "function", inputs: [{ name: "account", type: "address" }], outputs: [{ name: "", type: "uint256" }], stateMutability: "view" }] as const,
+              functionName: "balanceOf",
+              args: [address!],
+            }) as bigint;
+            balance = `$${(Number(bal) / 1_000_000).toFixed(4)} USDC`;
+          } catch { /* ignore */ }
+          const reason: string =
+            json?.invalidReason ??
+            json?.invalidMessage ??
+            (json?.error && json.error !== "Payment required" ? json.error : "") ??
+            "Unknown reason";
+          setErrorMsg(
+            `Payment verification failed: ${reason}. (Balance: ${balance})`,
+          );
+          setState("error");
+          return;
+        }
+        throw new Error(json.error ?? `Service error ${res.status}`);
+      }
+
       setResult(json);
       setState("done");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
-      if (
-        msg.toLowerCase().includes("rejected") ||
-        msg.toLowerCase().includes("denied") ||
-        msg.toLowerCase().includes("user rejected")
-      ) {
-        setState("denied");
+      if (msg.startsWith("__SIGN_REJECTED__")) {
+        setErrorMsg("You clicked Reject in MetaMask. Click \u2018Try Again\u2019 and then click \u2018Sign\u2019 in the MetaMask popup.");
       } else {
         setErrorMsg(msg);
-        setState("error");
       }
+      setState("error");
     }
   };
+
 
   return (
     <div className="my-2 rounded-xl border border-border bg-card shadow-sm overflow-hidden max-w-md">
@@ -172,34 +206,48 @@ export function PaymentApprovalCard({ request }: { request: PaymentRequest }) {
           </div>
         )}
 
-        <p className="text-xs text-muted-foreground">Network: Base Sepolia · USDC</p>
-        <p className="text-xs text-muted-foreground">Signing only — no gas required</p>
+        <p className="text-xs text-muted-foreground">Network: Base Sepolia � USDC</p>
+        <p className="text-xs text-muted-foreground">Signing only � no gas required</p>
+        
+        {/* Step hint shown before approval */}
+        {state === "idle" && (
+          <p className="text-xs text-muted-foreground/70">
+            MetaMask will show 1�2 prompts: switch network (if needed) then sign a gasless message.
+          </p>
+        )}
 
         {state === "idle" && (
           <div className="flex gap-2 pt-1">
             <Button size="sm" onClick={handleApprove} className="flex-1">
-              Approve & Sign
+              Approve &amp; Sign
             </Button>
             <Button size="sm" variant="outline" onClick={() => setState("denied")} className="flex-1">
-              Deny
+              Cancel
             </Button>
           </div>
         )}
 
         {state === "switching" && (
-          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="Switching to Base Sepolia…" />
-        )}
-        {state === "signing" && (
-          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="Sign the payment in your wallet (no gas)…" />
+          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="MetaMask: accept the \u2018Switch to Base Sepolia\u2019 prompt�" />
         )}
         {state === "calling" && (
-          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="Calling service…" />
+          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="Contacting service�" />
+        )}
+        {state === "signing" && (
+          <Status icon={<Loader2 className="h-4 w-4 animate-spin" />} text="MetaMask: click \u2018Sign\u2019 to authorise the gasless payment�" />
         )}
         {state === "denied" && (
-          <Status icon={<XCircle className="h-4 w-4 text-destructive" />} text="Payment denied." />
+          <div className="space-y-2">
+            <Status icon={<XCircle className="h-4 w-4 text-muted-foreground" />} text="Cancelled." />
+          </div>
         )}
         {state === "error" && (
-          <Status icon={<XCircle className="h-4 w-4 text-destructive" />} text={errorMsg} error />
+          <div className="space-y-2">
+            <Status icon={<XCircle className="h-4 w-4 text-destructive" />} text={errorMsg} error />
+            <Button size="sm" variant="outline" onClick={() => { setState("idle"); setErrorMsg(""); }} className="w-full">
+              Try Again
+            </Button>
+          </div>
         )}
         {state === "done" && result && (
           <div className="space-y-2">

--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -1,0 +1,33 @@
+/**
+ * Next.js instrumentation hook — runs once at server startup before any routes compile.
+ */
+export async function register() {
+  // Patch String.prototype.repeat to tolerate negative counts.
+  // React's dev-mode SSR error formatter contains ' '.repeat(i * 2 + 2) where
+  // `i` can be negative (Turbopack/Next.js 15 bug), causing RangeError that
+  // crashes the entire Node process. This makes it a no-op instead.
+  const _origRepeat = String.prototype.repeat;
+  String.prototype.repeat = function (this: string, count: number) {
+    if (count < 0) return "";
+    return _origRepeat.call(this, count);
+  };
+
+  if (typeof globalThis.indexedDB === "undefined") {
+    // Polyfill indexedDB to prevent WalletConnect SSR crash.
+    (globalThis as any).indexedDB = {
+      open: () => {
+        const req: any = {};
+        req.addEventListener = () => req;
+        req.removeEventListener = () => req;
+        return req;
+      },
+      deleteDatabase: () => {
+        const req: any = {};
+        req.addEventListener = () => req;
+        return req;
+      },
+      databases: () => Promise.resolve([]),
+      cmp: () => 0,
+    };
+  }
+}

--- a/frontend/src/styles/highlight-github.css
+++ b/frontend/src/styles/highlight-github.css
@@ -1,0 +1,118 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em
+}
+code.hljs {
+  padding: 3px 5px
+}
+/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+.hljs {
+  color: #24292e;
+  background: #ffffff
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #d73a49
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #005cc5
+}
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #032f62
+}
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #e36209
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #6a737d
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #22863a
+}
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e
+}
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold
+}
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f
+}
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic
+}
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold
+}
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4
+}
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0
+}
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+  
+}


### PR DESCRIPTION
- Local demo agent verifies EIP-712 TransferWithAuthorization signature against USDC on Base Sepolia (no on-chain settlement)
- LinkedIn jobs agent: paid (0.01 USDC) scraper for postings from the last 24h
- PaymentApprovalCard uses @x402/fetch wrapFetchWithPayment + RainbowKit getDefaultConfig
- agent-service route forwards X-PAYMENT / PAYMENT-RESPONSE headers transparently
- instrumentation.ts polyfills indexedDB + patches String.prototype.repeat for Turbopack SSR